### PR TITLE
ci: do not let black mangle the ci.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ exclude = """
   /(
     | .git
     | venv
+    | .github
   )/
 )
 """


### PR DESCRIPTION
Tell pyproject to ignore the .github directoy so we don't break the yaml.